### PR TITLE
feat: use eslint-plugin-userscripts typedefs

### DIFF
--- a/dist/linters/index.d.ts
+++ b/dist/linters/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../src/linters/eslint-plugin-userscripts.d.ts" />
 export type LintOptions = {
     fix?: boolean;
     isHomepageAllowed?: boolean;

--- a/src/linters/eslint-plugin-userscripts.d.ts
+++ b/src/linters/eslint-plugin-userscripts.d.ts
@@ -1,7 +1,0 @@
-declare module "eslint-plugin-userscripts" {
-    import { ESLint, Linter } from "eslint";
-
-    export const configs: Record<string, Linter.Config>;
-
-    export const rules: ESLint.Plugin["rules"];
-}

--- a/src/linters/index.ts
+++ b/src/linters/index.ts
@@ -1,5 +1,3 @@
-/// <reference path="./eslint-plugin-userscripts.d.ts" />
-
 import { ESLint } from "eslint";
 import { configs } from "eslint-plugin-userscripts";
 


### PR DESCRIPTION
With the publish of version [0.5.0](https://github.com/Yash-Singh1/eslint-plugin-userscripts/releases/tag/0.5.0), type definitions are now published alongside the package.